### PR TITLE
Implement dark-themed UI and manage categories with updated dependencies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -67,43 +67,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-			"integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-			"devOptional": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/gast": "10.5.0",
-				"@chevrotain/types": "10.5.0",
-				"lodash": "4.17.21"
-			}
-		},
-		"node_modules/@chevrotain/gast": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-			"integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-			"devOptional": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/types": "10.5.0",
-				"lodash": "4.17.21"
-			}
-		},
-		"node_modules/@chevrotain/types": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-			"integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-			"devOptional": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@chevrotain/utils": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-			"integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-			"devOptional": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -118,34 +81,34 @@
 			}
 		},
 		"node_modules/@electric-sql/pglite": {
-			"version": "0.3.15",
-			"resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
-			"integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+			"integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"peer": true
 		},
 		"node_modules/@electric-sql/pglite-socket": {
-			"version": "0.0.20",
-			"resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
-			"integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+			"integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"pglite-server": "dist/scripts/server.js"
 			},
 			"peerDependencies": {
-				"@electric-sql/pglite": "0.3.15"
+				"@electric-sql/pglite": "0.4.1"
 			}
 		},
 		"node_modules/@electric-sql/pglite-tools": {
-			"version": "0.2.20",
-			"resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
-			"integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+			"integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@electric-sql/pglite": "0.3.15"
+				"@electric-sql/pglite": "0.4.1"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -719,9 +682,9 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.9",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-			"integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+			"version": "1.19.11",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+			"integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -811,19 +774,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@mrleebo/prisma-ast": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
-			"integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
+		"node_modules/@kurkle/color": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+			"integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
 			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"chevrotain": "^10.5.0",
-				"lilconfig": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -902,15 +858,15 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/config": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.5.0.tgz",
-			"integrity": "sha512-1J/9YEX7A889xM46PYg9e8VAuSL1IUmXJW3tEhMv7XQHDWlfC9YSkIw9sTYRaq5GswGlxZ+GnnyiNsUZ9JJhSQ==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
+			"integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"c12": "3.1.0",
+				"c12": "3.3.4",
 				"deepmerge-ts": "7.1.5",
-				"effect": "3.18.4",
+				"effect": "3.20.0",
 				"empathic": "2.0.0"
 			}
 		},
@@ -921,22 +877,22 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/dev": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
-			"integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+			"version": "0.24.3",
+			"resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+			"integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
 			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
-				"@electric-sql/pglite": "0.3.15",
-				"@electric-sql/pglite-socket": "0.0.20",
-				"@electric-sql/pglite-tools": "0.2.20",
-				"@hono/node-server": "1.19.9",
-				"@mrleebo/prisma-ast": "0.13.1",
+				"@electric-sql/pglite": "0.4.1",
+				"@electric-sql/pglite-socket": "0.1.1",
+				"@electric-sql/pglite-tools": "0.3.1",
+				"@hono/node-server": "1.19.11",
 				"@prisma/get-platform": "7.2.0",
 				"@prisma/query-plan-executor": "7.2.0",
+				"@prisma/streams-local": "0.1.2",
 				"foreground-child": "3.3.1",
 				"get-port-please": "3.2.0",
-				"hono": "4.11.4",
+				"hono": "^4.12.8",
 				"http-status-codes": "2.3.0",
 				"pathe": "2.0.3",
 				"proper-lockfile": "4.1.2",
@@ -956,70 +912,70 @@
 			}
 		},
 		"node_modules/@prisma/engines": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.5.0.tgz",
-			"integrity": "sha512-ondGRhzoaVpRWvFaQ5wH5zS1BIbhzbKqczKjCn6j3L0Zfe/LInjcEg8+xtB49AuZBX30qyx1ZtGoootUohz2pw==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
+			"integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "7.5.0",
-				"@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-				"@prisma/fetch-engine": "7.5.0",
-				"@prisma/get-platform": "7.5.0"
+				"@prisma/debug": "7.8.0",
+				"@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+				"@prisma/fetch-engine": "7.8.0",
+				"@prisma/get-platform": "7.8.0"
 			}
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e.tgz",
-			"integrity": "sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==",
+			"version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
+			"integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/engines/node_modules/@prisma/debug": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
-			"integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+			"integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
-			"integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+			"integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "7.5.0"
+				"@prisma/debug": "7.8.0"
 			}
 		},
 		"node_modules/@prisma/fetch-engine": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.5.0.tgz",
-			"integrity": "sha512-kZCl2FV54qnyrVdnII8MI6qvt7HfU6Cbiz8dZ8PXz4f4lbSw45jEB9/gEMK2SGdiNhBKyk/Wv95uthoLhGMLYA==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
+			"integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "7.5.0",
-				"@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-				"@prisma/get-platform": "7.5.0"
+				"@prisma/debug": "7.8.0",
+				"@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+				"@prisma/get-platform": "7.8.0"
 			}
 		},
 		"node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
-			"integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+			"integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
-			"integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+			"integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "7.5.0"
+				"@prisma/debug": "7.8.0"
 			}
 		},
 		"node_modules/@prisma/get-platform": {
@@ -1046,20 +1002,212 @@
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/@prisma/studio-core": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.21.1.tgz",
-			"integrity": "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==",
+		"node_modules/@prisma/streams-local": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+			"integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"ajv": "^8.12.0",
+				"better-result": "^2.7.0",
+				"env-paths": "^3.0.0",
+				"proper-lockfile": "^4.1.2"
+			},
 			"engines": {
-				"node": "^20.19 || ^22.12 || ^24.0",
+				"bun": ">=1.3.6",
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@prisma/streams-local/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@prisma/streams-local/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"devOptional": true,
+			"license": "MIT"
+		},
+		"node_modules/@prisma/studio-core": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+			"integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@radix-ui/react-toggle": "1.1.10",
+				"chart.js": "4.5.1"
+			},
+			"engines": {
+				"node": "^20.19 || ^22.12 || >=24.0",
 				"pnpm": "8"
 			},
 			"peerDependencies": {
 				"@types/react": "^18.0.0 || ^19.0.0",
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+			"integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+			"devOptional": true,
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"devOptional": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-toggle": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+			"integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+			"integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-effect-event": "0.0.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+			"integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+			"integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@standard-schema/spec": {
@@ -1677,9 +1825,9 @@
 			}
 		},
 		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1757,6 +1905,13 @@
 				"bcrypt": "bin/bcrypt"
 			}
 		},
+		"node_modules/better-result": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.2.tgz",
+			"integrity": "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==",
+			"devOptional": true,
+			"license": "MIT"
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1795,9 +1950,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1842,45 +1997,32 @@
 			}
 		},
 		"node_modules/c12": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
-			"integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+			"integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"chokidar": "^4.0.3",
-				"confbox": "^0.2.2",
-				"defu": "^6.1.4",
-				"dotenv": "^16.6.1",
-				"exsolve": "^1.0.7",
-				"giget": "^2.0.0",
-				"jiti": "^2.4.2",
+				"chokidar": "^5.0.0",
+				"confbox": "^0.2.4",
+				"defu": "^6.1.6",
+				"dotenv": "^17.3.1",
+				"exsolve": "^1.0.8",
+				"giget": "^3.2.0",
+				"jiti": "^2.6.1",
 				"ohash": "^2.0.11",
 				"pathe": "^2.0.3",
-				"perfect-debounce": "^1.0.0",
-				"pkg-types": "^2.2.0",
-				"rc9": "^2.1.2"
+				"perfect-debounce": "^2.1.0",
+				"pkg-types": "^2.3.0",
+				"rc9": "^3.0.1"
 			},
 			"peerDependencies": {
-				"magicast": "^0.3.5"
+				"magicast": "*"
 			},
 			"peerDependenciesMeta": {
 				"magicast": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/c12/node_modules/dotenv": {
-			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-			"devOptional": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -1928,45 +2070,33 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/chevrotain": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-			"integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
+		"node_modules/chart.js": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+			"integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
 			"devOptional": true,
-			"license": "Apache-2.0",
+			"license": "MIT",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "10.5.0",
-				"@chevrotain/gast": "10.5.0",
-				"@chevrotain/types": "10.5.0",
-				"@chevrotain/utils": "10.5.0",
-				"lodash": "4.17.21",
-				"regexp-to-ast": "0.5.0"
+				"@kurkle/color": "^0.3.0"
+			},
+			"engines": {
+				"pnpm": ">=8"
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"readdirp": "^4.0.1"
+				"readdirp": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 14.16.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/citty": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"consola": "^3.2.3"
 			}
 		},
 		"node_modules/clean-stack": {
@@ -2035,16 +2165,6 @@
 			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
 			"devOptional": true,
 			"license": "MIT"
-		},
-		"node_modules/consola": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-			"devOptional": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.18.0 || >=16.10.0"
-			}
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -2175,9 +2295,9 @@
 			}
 		},
 		"node_modules/defu": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+			"integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
 			"devOptional": true,
 			"license": "MIT"
 		},
@@ -2321,9 +2441,9 @@
 			"license": "MIT"
 		},
 		"node_modules/effect": {
-			"version": "3.18.4",
-			"resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-			"integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+			"integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2363,6 +2483,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+			"devOptional": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/error-ex": {
@@ -2752,7 +2885,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -2796,6 +2929,23 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"devOptional": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
@@ -2902,9 +3052,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-			"integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3056,19 +3206,11 @@
 			}
 		},
 		"node_modules/giget": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-			"integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
+			"integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
 			"devOptional": true,
 			"license": "MIT",
-			"dependencies": {
-				"citty": "^0.1.6",
-				"consola": "^3.4.0",
-				"defu": "^6.1.4",
-				"node-fetch-native": "^1.6.6",
-				"nypm": "^0.6.0",
-				"pathe": "^2.0.3"
-			},
 			"bin": {
 				"giget": "dist/cli.mjs"
 			}
@@ -3114,9 +3256,9 @@
 			"license": "MIT"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -3233,9 +3375,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.11.4",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-			"integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+			"version": "4.12.17",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+			"integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
@@ -3612,16 +3754,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/lilconfig": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-			"devOptional": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -3643,13 +3775,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"devOptional": true,
-			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
@@ -3782,9 +3907,9 @@
 			}
 		},
 		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -3930,13 +4055,6 @@
 				"node": "^18 || ^20 || >= 21"
 			}
 		},
-		"node_modules/node-fetch-native": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-			"integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-			"devOptional": true,
-			"license": "MIT"
-		},
 		"node_modules/node-gyp-build": {
 			"version": "4.8.4",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -4026,9 +4144,9 @@
 			}
 		},
 		"node_modules/nodemon/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4106,31 +4224,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/nypm": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-			"integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"citty": "^0.2.0",
-				"pathe": "^2.0.3",
-				"tinyexec": "^1.0.2"
-			},
-			"bin": {
-				"nypm": "dist/cli.mjs"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/nypm/node_modules/citty": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-			"integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-			"devOptional": true,
-			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -4320,9 +4413,9 @@
 			"license": "MIT"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -4346,9 +4439,9 @@
 			"license": "MIT"
 		},
 		"node_modules/perfect-debounce": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
 			"devOptional": true,
 			"license": "MIT"
 		},
@@ -4458,9 +4551,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -4472,14 +4565,14 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+			"integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"confbox": "^0.2.2",
-				"exsolve": "^1.0.7",
+				"confbox": "^0.2.4",
+				"exsolve": "^1.0.8",
 				"pathe": "^2.0.3"
 			}
 		},
@@ -4547,18 +4640,18 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
-			"integrity": "sha512-n30qZpWehaYQzigLjmuPisyEsvOzHt7bZeRyg8gZ5DvJo9FGjD+gNaY59Ns3hlLD5/jZH5GBeftIss0jDbUoLg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
+			"integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@prisma/config": "7.5.0",
-				"@prisma/dev": "0.20.0",
-				"@prisma/engines": "7.5.0",
-				"@prisma/studio-core": "0.21.1",
+				"@prisma/config": "7.8.0",
+				"@prisma/dev": "0.24.3",
+				"@prisma/engines": "7.8.0",
+				"@prisma/studio-core": "0.27.3",
 				"mysql2": "3.15.3",
 				"postgres": "3.4.7"
 			},
@@ -4717,20 +4810,20 @@
 			}
 		},
 		"node_modules/rc9": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-			"integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+			"integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"defu": "^6.1.4",
-				"destr": "^2.0.3"
+				"defu": "^6.1.6",
+				"destr": "^2.0.5"
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.4",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
 			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
@@ -4739,9 +4832,9 @@
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.4",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
 			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
@@ -4749,7 +4842,7 @@
 				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.4"
+				"react": "^19.2.5"
 			}
 		},
 		"node_modules/read-pkg": {
@@ -4768,25 +4861,18 @@
 			}
 		},
 		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 14.18.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
 			}
-		},
-		"node_modules/regexp-to-ast": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-			"integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-			"devOptional": true,
-			"license": "MIT"
 		},
 		"node_modules/remeda": {
 			"version": "2.33.4",
@@ -4796,6 +4882,16 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/remeda"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"devOptional": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve": {
@@ -5368,16 +5464,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/tinyexec": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-			"devOptional": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5567,9 +5653,9 @@
 			}
 		},
 		"node_modules/ts-node-dev/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5759,9 +5845,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2671,14 +2671,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4042,9 +4042,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5907,9 +5907,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5958,10 +5958,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",


### PR DESCRIPTION
This pull request updates several dependencies in the `frontend/package-lock.json` file to their latest versions, focusing on improving security, compatibility, and stability. The most important changes are grouped below by theme:

**Dependency Updates:**

* Upgraded `axios` from version 1.13.6 to 1.16.0, which also updates its dependencies for improved stability and security.
* Updated `follow-redirects` from 1.15.11 to 1.16.0, ensuring compatibility with the latest `axios` version.
* Upgraded `proxy-from-env` from 1.1.0 to 2.1.0, which now specifies a minimum Node.js version and includes other improvements.

**Build Tooling Improvements:**

* Updated `postcss` from 8.5.8 to 8.5.14, addressing potential security vulnerabilities and improving CSS processing during builds.